### PR TITLE
Use endsWith comparison

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ class ElmCSSCompiler {
     );
   }
   compile(file) {
-    if (file.path !== this.pluginConfig.sourcePath && !this.ranAtLeastOnce) {
+    if (!file.path.endsWith(this.pluginConfig.sourcePath) && !this.ranAtLeastOnce) {
       // The initial build will match everything, but we don't want to
       // build elm-css for n number of files, just once is fine.
       //


### PR DESCRIPTION
This PR makes my `brunch build` work. My scenario is a "traditional" one for phoenix 1.2.
These are the relevant configs in `brunch-config.js`:

```c#
  conventions: {
    // This option sets where we should place non-css and non-js assets in.
    // By default, we set this to "/web/static/assets". Files in this directory
    // will be copied to `paths.public`, which is "priv/static" by default.
    assets: /^(web\/static\/assets)/,
    ignored: [/elm-stuff/]
  },

  paths: {
    // Dependencies and current project directories to watch
    watched: [
      'web/static',
      'test/static',
      'web/elm'
    ],

    // Where to compile files to
    public: 'priv/static',
  },

  plugins: {
    babel: {
      // Do not use ES6 compiler in vendor code
      ignore: [/web\/static\/vendor/],
    },
    elmBrunch: {
      elmFolder: 'web/elm',
      mainModules: ['src/Main.elm'],
      outputFolder: '../static/vendor',
      makeParameters: ['--debug']
    },
    elmCss: {
      projectDir: `web/elm`, // relative to the location of `brunch-config.js`
      sourcePath: 'src/Stylesheets.elm', // relative to `projectDir`
      outputDir: `../static/css`, // relative to `projectDir`
    }
  },
```

Please keep in mind that I am not familiar with `brunch`. Take this PR with a grain of salt. 
I don't know if this PR can have any impact on the `pattern` feature. I am not using this `patern` feature.

Kudos to you Dustin and thank you for your time and precious help on Slack 👍 